### PR TITLE
Revised Get-SQLDefaultPaths function

### DIFF
--- a/Restore-HallengrenBackups.ps1
+++ b/Restore-HallengrenBackups.ps1
@@ -214,7 +214,7 @@ Function Get-SQLDefaultPaths     {
             [string]$filetype
 		)
 		
-	switch ($filetype) { "data" { $filetype = "mdf" } "log" {  $filetype = "ldf" } }
+	switch ($filetype) { "mdf" { $filetype = "data" } "ldf" {  $filetype = "log" } }
 	
 	if ($filetype -eq "log") {
 		# First attempt
@@ -240,7 +240,7 @@ Function Get-SQLDefaultPaths     {
 	
 	if ($filepath.Length -eq 0) { throw "Cannot determine the required directory path." }
 	$filepath = $filepath.TrimEnd("\")
-	return Split-Path($filepath)
+	return $filepath
 }
 
 Function Test-SQLSA      {


### PR DESCRIPTION
I had to remove the split-path($filepath), on systems with mount points and shallow directory structures it was reverting to folders which lacked permissions.  Also revised the switch which was replacing "data" with "mdf" and "log" with "ldf" which was bypassing the conditional test and assignment of the default path. After making these changes it worked on my 2008r2 system.
